### PR TITLE
parse timestamp string to integer

### DIFF
--- a/lib/queueit.js
+++ b/lib/queueit.js
@@ -343,7 +343,7 @@ module.exports = function(options)
         verifyTimestamp: function(timestamp) {
             var currentTimestamp = Math.floor(new Date() / 1000);
             var expire = 4*60; // The link expires after 4 minutes
-            return timestamp + expire > currentTimestamp;
+            return parseInt(timestamp) + expire > currentTimestamp;
         },
 
         getQueueUrl: function(req, res, target) {


### PR DESCRIPTION
Timestamp from the query parameter was passed to verifyTimestamp as a string, so the expression was always evaluating to true even after expiry. 