### PR TITLE
Extend cookie duration refactor

### DIFF
--- a/lib/queueit.js
+++ b/lib/queueit.js
@@ -192,12 +192,11 @@ module.exports = function(options)
         },
 
         setCookie: function(res, queueId, originalUrl, placeInQueue, redirectType, timestamp) {
-            var expiration = this.toISOStringWithExtraPrecision((new Date(new Date().getTime() + options.cookieExpiration)));
-            if (redirectType == "Idle")
-            {
-                expiration = this.toISOStringWithExtraPrecision((new Date(new Date().getTime() + options.idleExpiration)));
-            }
-
+            var extendExpirationBy = redirectType == 'Idle' ? options.idleExpiration :  options.cookieExpiration
+            var expiration = this.toISOStringWithExtraPrecision(
+                new Date(new Date().getTime() + extendExpirationBy)
+            )
+            
             var cookie = {
                 QueueId: queueId,
                 OriginalUrl: originalUrl,


### PR DESCRIPTION
Setting a variable for how long to extend cookie expiration for so that expiration only needs to be set once.